### PR TITLE
Enable CORS for People API

### DIFF
--- a/HelloApi/Program.cs
+++ b/HelloApi/Program.cs
@@ -6,6 +6,13 @@ var builder = WebApplication.CreateBuilder(args);
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy =>
+        policy.AllowAnyOrigin()
+              .AllowAnyHeader()
+              .AllowAnyMethod());
+});
 
 var connectionString = builder.Configuration.GetConnectionString("Default")!;
 builder.Services.AddScoped<NpgsqlConnection>(_ => new NpgsqlConnection(connectionString));
@@ -20,6 +27,7 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+app.UseCors();
 
 app.MapGet("/hello", () => "Hello World!");
 


### PR DESCRIPTION
## Summary
- allow cross-origin requests by adding CORS middleware

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68410ae918a4832c94c993d4e1b2ce9a