### PR TITLE
Fix AG Grid module registration

### DIFF
--- a/people-ui/src/main.ts
+++ b/people-ui/src/main.ts
@@ -2,6 +2,9 @@ import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { App } from './app/app';
 import 'bootstrap/dist/js/bootstrap.bundle.min.js';
+import { ModuleRegistry, AllCommunityModule } from 'ag-grid-community';
+
+ModuleRegistry.registerModules([AllCommunityModule]);
 
 bootstrapApplication(App, appConfig)
   .catch((err) => console.error(err));


### PR DESCRIPTION
## Summary
- register `AllCommunityModule` in AG Grid bootstrap

## Testing
- `npm test` *(fails: `ng` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68439880e2a8832c94dbc091c3e8597b